### PR TITLE
Reduces the CA link permiability betweek the Universal Hub and connec…

### DIFF
--- a/dev/Catallipac/CAT-installation.pray.cos
+++ b/dev/Catallipac/CAT-installation.pray.cos
@@ -306,7 +306,7 @@ scrp 1 2 24403 1000
 		bhvr 1
 		tran 0 0
 * 			link the rooms, spread the CA around
-		link va00 room targ 100
+		link va00 room targ 5
 ** 			set the entry
 		setv ov00 1
 		setv ov01 1

--- a/dev/Daedalus/DAE-installation.pray.cos
+++ b/dev/Daedalus/DAE-installation.pray.cos
@@ -526,7 +526,7 @@ scrp 1 2 24403 1000
 		bhvr 1
 		tran 0 0
 ** link the rooms, spread the CA around
-		link va00 room targ 100
+		link va00 room targ 5
 		setv ov00 1
 		setv ov01 1
 		setv ov02 1

--- a/dev/Morpheri/Mor-installation.pray.cos
+++ b/dev/Morpheri/Mor-installation.pray.cos
@@ -407,7 +407,7 @@ scrp 1 2 24403 1000
 		bhvr 1
 		tran 0 0
 ** link the rooms, spread the CA around
-		link va00 room targ 100
+		link va00 room targ 5
 		setv ov00 1
 		setv ov01 1
 		setv ov02 1

--- a/dev/Universal Hub/CoC.catalogue
+++ b/dev/Universal Hub/CoC.catalogue
@@ -74,7 +74,7 @@ TAG "zot_CAT"
 "This is the Catillipac!\nIt features the Enhances Empathic Vendor and a heat pan like the one in the meso."
 
 TAG "zot_UH"
-"This is the Universal Hub!\nIt has eight doors for future expansion by all developers. Contact Zzzzoot if you want to use one.\n\nThe Universal Hub is essential for using any other Children of Capillata rooms, as it connects them to the main ship."
+"This is the Universal Hub! It's a bit windy in here.\nIt has eight doors for future expansion by all developers. Contact Zzzzoot if you want to use one.\n\nThe Universal Hub is essential for using any other Children of Capillata rooms, as it connects them to the main ship."
 
 TAG "zot_DAE"
 "This is Daedalus!\nIt features environment control exactly like the one in C3; carrot, lemon, and justanut vendors; and potted plants that grow lemons and justanuts."

--- a/dev/Universal Hub/UH-Installation.pray.cos
+++ b/dev/Universal Hub/UH-Installation.pray.cos
@@ -217,7 +217,7 @@ scrp 1 2 24403 1000
 * UH side door
 		new: comp 2 2 24402 "CoCUHdoor" 4 5 0
 		mvto 41666 29622
-		link va00 room targ 100
+		link va00 room targ 5
 
 *	************
 *	***//Door***


### PR DESCRIPTION
…ted meta rooms

Previously the very high (100) CA link between all the meta rooms, and the very close proximity to the Empathic Vendor, combined to cause norns to think the Universal Hub had actual food in it and they would starve there.